### PR TITLE
How to enable Disqus comments

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -3,7 +3,7 @@ languageCode: "en-us"
 title: "A minimal Hugo website"
 theme: "hugo-xmin"
 googleAnalytics: ""
-disqusShortname: ""
+disqusShortname: "yihui"
 ignoreFiles: ["\\.Rmd$", "\\.Rmarkdown$", "_cache$"]
 footnotereturnlinkcontents: "↩"
 

--- a/exampleSite/layouts/_partials/foot_custom.html
+++ b/exampleSite/layouts/_partials/foot_custom.html
@@ -1,7 +1,6 @@
 <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-<script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/math-code.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/katex/dist/katex.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/katex/dist/contrib/auto-render.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/render-katex.js" defer></script>
+<script src="//cdn.jsdelivr.net/combine/npm/katex/dist/katex.min.js,npm/katex/dist/contrib/auto-render.min.js,npm/@xiee/utils/js/render-katex.js" defer></script>
 
 <script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/center-img.min.js" defer></script>
+
+{{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
Add `{{ template "_internal/disqus.html" . }}` to `foot_custom.html`, and configure the Disqus shortname in `config.toml`.

Preview: https://deploy-preview-4--hugo-xmin.netlify.com/