### PR TITLE
How to enable highlight.js for syntax highlighting of code blocks

### DIFF
--- a/exampleSite/layouts/_partials/foot_custom.html
+++ b/exampleSite/layouts/_partials/foot_custom.html
@@ -1,7 +1,12 @@
 <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-<script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/math-code.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/katex/dist/katex.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/katex/dist/contrib/auto-render.min.js" defer></script>
-<script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/render-katex.js" defer></script>
+<script src="//cdn.jsdelivr.net/combine/npm/katex/dist/katex.min.js,npm/katex/dist/contrib/auto-render.min.js,npm/@xiee/utils/js/render-katex.js" defer></script>
 
 <script src="//cdn.jsdelivr.net/npm/@xiee/utils/js/center-img.min.js" defer></script>
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/languages/r.min.js"></script>
+
+<script>
+hljs.configure({languages: []});
+hljs.initHighlightingOnLoad();
+</script>

--- a/exampleSite/layouts/_partials/head_custom.html
+++ b/exampleSite/layouts/_partials/head_custom.html
@@ -1,0 +1,1 @@
+<link href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/github.min.css" rel="stylesheet">


### PR DESCRIPTION
Add CSS to `<head>` in `head_custom.html` (I'm using the `github` theme here), and JavaScript to `foot_custom.html`. `highlight.min.js` supports common languages here: https://highlightjs.org/download/ As an example, I added `r.min.js` to support R. To add support for any other languages, find their filenames on https://cdnjs.com/libraries/highlight.js.

`hljs.configure({languages: []});` means highlight.js should not automatically detect languages in `<pre>`. I set this option because I found the automatic detection was often more annoying than useful, e.g. your R code chunk output could be syntax highlighted, which really should not be.

Preview: https://deploy-preview-5--hugo-xmin.netlify.com/