### PR TITLE
How to add a Github edit link automatically to a page

### DIFF
--- a/exampleSite/content/post/2017-06-21-an-r-markdown-example.Rmarkdown
+++ b/exampleSite/content/post/2017-06-21-an-r-markdown-example.Rmarkdown
@@ -1,0 +1,19 @@
+---
+title: An R Markdown Example
+author: Yihui Xie
+date: '2017-06-21'
+categories:
+  - Example
+  - R
+tags:
+  - blogdown
+slug: an-r-markdown-example
+---
+
+This is a simple R Markdown example, with a single R code chunk below.
+
+```{r}
+knitr::kable(head(mtcars))
+```
+
+The table shows the first 6 rows of the `mtcars` dataset in base R.

--- a/exampleSite/content/post/2017-06-21-an-r-markdown-example.markdown
+++ b/exampleSite/content/post/2017-06-21-an-r-markdown-example.markdown
@@ -1,0 +1,31 @@
+---
+title: An R Markdown Example
+author: Yihui Xie
+date: '2017-06-21'
+categories:
+  - Example
+  - R
+tags:
+  - blogdown
+slug: an-r-markdown-example
+---
+
+This is a simple R Markdown example, with a single R code chunk below.
+
+
+```r
+knitr::kable(head(mtcars))
+```
+
+
+
+|                  |  mpg| cyl| disp|  hp| drat|    wt|  qsec| vs| am| gear| carb|
+|:-----------------|----:|---:|----:|---:|----:|-----:|-----:|--:|--:|----:|----:|
+|Mazda RX4         | 21.0|   6|  160| 110| 3.90| 2.620| 16.46|  0|  1|    4|    4|
+|Mazda RX4 Wag     | 21.0|   6|  160| 110| 3.90| 2.875| 17.02|  0|  1|    4|    4|
+|Datsun 710        | 22.8|   4|  108|  93| 3.85| 2.320| 18.61|  1|  1|    4|    1|
+|Hornet 4 Drive    | 21.4|   6|  258| 110| 3.08| 3.215| 19.44|  1|  0|    3|    1|
+|Hornet Sportabout | 18.7|   8|  360| 175| 3.15| 3.440| 17.02|  0|  0|    3|    2|
+|Valiant           | 18.1|   6|  225| 105| 2.76| 3.460| 20.22|  1|  0|    3|    1|
+
+The table shows the first 6 rows of the `mtcars` dataset in base R.

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -31,6 +31,7 @@ menu:
 params:
   description: "A website built through Hugo and blogdown."
   footer: "&copy; [Yihui Xie](https://yihui.org) 2017 -- {Year} | [Github](https://github.com/yihui) | [BlueSky](https://bsky.app/profile/yihui.org)"
+  GithubEdit: "https://github.com/yihui/hugo-xmin/edit/feature/github-edit/exampleSite/content/"
 
 markup:
   highlight:

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -4,6 +4,17 @@
   <hr/>
   {{ replace . "{Year}" now.Year | markdownify }}
   {{ end }}
+  {{ if .File.Path }}
+  {{ $RmdFile := (print .File.BaseFileName ".Rmd") }}
+  {{ if (where (readDir (print "content/" .File.Dir)) "Name" $RmdFile) }}
+    {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
+  {{ else }}
+    {{ $.Scratch.Set "FilePath" .File.Path }}
+  {{ end }}
+  {{ with .Site.Params.GithubEdit}}
+  | <a href="{{ . }}{{ $.Scratch.Get "FilePath" }}">Edit this page</a>
+  {{ end }}
+  {{ end }}
   </footer>
   </body>
 </html>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -5,15 +5,20 @@
   {{ replace . "{Year}" now.Year | markdownify }}
   {{ end }}
   {{ if .File.Path }}
-  {{ $RmdFile := (print .File.BaseFileName ".Rmd") }}
-  {{ if (where (readDir (print "content/" .File.Dir)) "Name" $RmdFile) }}
-    {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
-  {{ else }}
     {{ $.Scratch.Set "FilePath" .File.Path }}
-  {{ end }}
-  {{ with .Site.Params.GithubEdit}}
-  | <a href="{{ . }}{{ $.Scratch.Get "FilePath" }}">Edit this page</a>
-  {{ end }}
+    {{ $RmdFile := (print .File.BaseFileName ".Rmd") }}
+    {{ $Files := readDir (print "content/" .File.Dir) }}
+    {{ if (where $Files "Name" $RmdFile) }}
+      {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
+    {{ else }}
+      {{ $RmdFile := (print .File.BaseFileName ".Rmarkdown") }}
+      {{ if (where $Files "Name" $RmdFile) }}
+        {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
+      {{ end }}
+    {{ end }}
+    {{ with .Site.Params.GithubEdit}}
+    | <a href="{{ . }}{{ $.Scratch.Get "FilePath" }}">Edit this page</a>
+    {{ end }}
   {{ end }}
   </footer>
   </body>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -4,19 +4,19 @@
   <hr/>
   {{ replace . "{Year}" now.Year | markdownify }}
   {{ end }}
-  {{ if .File.Path }}
-    {{ $.Scratch.Set "FilePath" .File.Path }}
-    {{ $RmdFile := (print .File.BaseFileName ".Rmd") }}
-    {{ $Files := readDir (print "content/" .File.Dir) }}
+  {{ with .File }}
+    {{ $.Scratch.Set "FilePath" .Path }}
+    {{ $RmdFile := (print .BaseFileName ".Rmd") }}
+    {{ $Files := readDir (print "content/" .Dir) }}
     {{ if (where $Files "Name" $RmdFile) }}
-      {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
+      {{ $.Scratch.Set "FilePath" (print .Dir $RmdFile) }}
     {{ else }}
-      {{ $RmdFile := (print .File.BaseFileName ".Rmarkdown") }}
+      {{ $RmdFile := (print .BaseFileName ".Rmarkdown") }}
       {{ if (where $Files "Name" $RmdFile) }}
-        {{ $.Scratch.Set "FilePath" (print .File.Dir $RmdFile) }}
+        {{ $.Scratch.Set "FilePath" (print .Dir $RmdFile) }}
       {{ end }}
     {{ end }}
-    {{ with .Site.Params.GithubEdit}}
+    {{ with $.Site.Params.GithubEdit}}
     | <a href="{{ . }}{{ $.Scratch.Get "FilePath" }}">Edit this page</a>
     {{ end }}
   {{ end }}


### PR DESCRIPTION
This PR contains two commits. The first commit is the implementation, and the second commit only contains two examples.

You should read https://bookdown.org/yihui/blogdown/templates.html and replace the edit link (`GithubEdit`) `https://github.com/yihui/hugo-xmin/edit/feature/github-edit/exampleSite/content/` with your own link. You must replace the USER (`yihui`), REPO (`hugo-xmin`), BRANCH (`feature/github-edit`), and the path after BRANCH (`exampleSite/content/`) depending on your repo settings. In most cases, `BRANCH` is most likely to be `master`, and the path is likely to be `content/`. Please do not blindly follow my `GithubEdit` link here. You should understand what each part means exactly.

Preview at https://deploy-preview-6--hugo-xmin.netlify.com/ (see the link "Edit this page" in the footer of every page).