### PR TITLE
Fix centering on menu in header (style.css change)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,6 +6,7 @@ body {
 }
 
 /* header and footer areas */
+.menu { padding: 0; }
 .menu li { display: inline-block; }
 .article-meta, .menu a {
   text-decoration: none;
@@ -13,11 +14,7 @@ body {
   padding: 5px;
   border-radius: 5px;
 }
-.article-meta, footer { text-align: center; }
-.menu { 
-  text-align: center;
-  padding:0px;
-}
+.menu, .article-meta, footer { text-align: center; }
 .title { font-size: 1.1em; }
 footer a { text-decoration: none; }
 hr {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,7 +13,11 @@ body {
   padding: 5px;
   border-radius: 5px;
 }
-.menu, .article-meta, footer { text-align: center; }
+.article-meta, footer { text-align: center; }
+.menu { 
+  text-align: center;
+  padding:0px;
+}
 .title { font-size: 1.1em; }
 footer a { text-decoration: none; }
 hr {


### PR DESCRIPTION
Since menu "li" items normally add padding, it off-centers the menu. Changing .menu padding to 0px fixes this.
This also gives back some valuable real estate on mobile devices for menu items.