### PR TITLE
How to display a fixed number of posts per page (i.e. pagination)

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -6,6 +6,8 @@ googleAnalytics: ""
 disqusShortname: ""
 ignoreFiles: ["\\.Rmd$", "\\.Rmarkdown$", "_cache$"]
 footnotereturnlinkcontents: "↩"
+pagination:
+  pagerSize: 1
 
 permalinks:
   note: "/note/:year/:month/:day/:slug/"

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -9,12 +9,14 @@
 <ul>
   {{ $pages := .Pages }}
   {{ if .IsHome }}{{ $pages = .Site.RegularPages }}{{ end }}
-  {{ range (where $pages "Section" "!=" "") }}
+  {{ $paginator := .Paginate (where $pages "Section" "!=" "") }}
+  {{ range $paginator.Pages }}
   <li>
     <span class="date">{{ .Date.Format "2006/01/02" }}</span>
     <a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
   </li>
   {{ end }}
 </ul>
+{{ template "_internal/pagination.html" . }}
 
 {{ partial "footer.html" . }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -22,6 +22,11 @@ hr {
   color: #ddd;
 }
 
+/* pagination */
+.pagination { text-align: center; }
+.pagination li { display: inline; }
+.pagination a { padding: 0 .2em; }
+
 /* code */
 pre {
   border: 1px solid #ddd;


### PR DESCRIPTION
Normally when you list posts, you use something like `range .Data.Pages`, which will show all posts in a single list. Sometimes when you have a large number of posts, you may want to show, for example, 10 posts per page, and provide a navigation menu so that readers can go to the next/previous 10 posts. In this case, you can apply `.Paginate` to `.Data.Pages`, e.g. `range (.Paginate .Data.Pages)`, and Hugo will automatically retrieve a subset of posts for you to list.

Hugo has provided an internal pagination template to build the navigation menu that consists of page numbers:

```
{{ template "_internal/pagination.html" . }}
```

Lastly, you may need to tweak the CSS to display the navigation menu appropriately.

In this example, I set `paginate = 1` in `config.toml`, which is an extreme case. Its default value is 10 (i.e. 10 posts per page). I only have four posts on this example website, and I just want to display them on four pages as an example.

Preview:

- Homepage: https://deploy-preview-16--hugo-xmin.netlify.com/
- Posts: https://deploy-preview-16--hugo-xmin.netlify.com/post/
- Taxonomy: https://deploy-preview-16--hugo-xmin.netlify.com/tags/markdown

Documentation of pagination in Hugo: https://gohugo.io/templates/pagination/