### PR TITLE
Add an 'Updated' entry to the single page banner

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,6 +3,7 @@
 <h1><span class="title">{{ .Title | markdownify }}</span></h1>
 {{ with .Params.author }}<h2 class="author">{{ . }}</h2>{{ end }}
 {{ if (gt .Params.date 0) }}<h2 class="date">{{ .Date.Format "2006/01/02" }}</h2>{{ end }}
+{{ if not (eq .Lastmod .Date) }}<span class="lastmod">Updated {{ .Lastmod.Format "2006/01/02" }}</span>{{ end }}
 </div>
 
 <main>


### PR DESCRIPTION
For the banner header on "single" page layouts, adds an "Updated" line if the lastmod value doesn't match the date - i.e. if the page has been updated and an explicit entry has been added to the frontmatter.