### PR TITLE
Cleaner and more specific way to implement comment section for posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "A minimal Hugo website"
 theme = "hugo-xmin"
 googleAnalytics = ""
-disqusShortname = ""
+disqusShortname = "yihui"
 ignoreFiles = ["\\.Rmd$", "\\.Rmarkdown$", "_files$", "_cache$"]
 footnotereturnlinkcontents = "↩"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,3 +34,4 @@ footnotereturnlinkcontents = "↩"
 [params]
     description = "A website built through Hugo and blogdown."
     footer = "&copy; [Yihui Xie](https://yihui.name) 2017 -- 2019 | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
+    enable_comments = true

--- a/exampleSite/layouts/partials/foot_custom.html
+++ b/exampleSite/layouts/partials/foot_custom.html
@@ -2,3 +2,5 @@
 <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 <script async src="//yihui.name/js/center-img.js"></script>
+
+{{ template "_internal/disqus.html" . }}

--- a/exampleSite/layouts/partials/foot_custom.html
+++ b/exampleSite/layouts/partials/foot_custom.html
@@ -2,5 +2,3 @@
 <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 <script async src="//yihui.name/js/center-img.js"></script>
-
-{{ template "_internal/disqus.html" . }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,0 +1,14 @@
+{{ partial "header.html" . }}
+<div class="article-meta">
+<h1><span class="title">{{ .Title | markdownify }}</span></h1>
+{{ with .Params.author }}<h2 class="author">{{ . }}</h2>{{ end }}
+{{ if (gt .Params.date 0) }}<h2 class="date">{{ .Date.Format "2006/01/02" }}</h2>{{ end }}
+</div>
+
+<main>
+{{ .Content }}
+</main>
+{{ if .Params.enable_comments }}
+{{ template "_internal/disqus.html" . }}
+{{ end }}
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Hello Yihui, 

This is my implementation of the comment section that is only specific to posts I [mentioned](https://github.com/yihui/hugo-xmin/pull/4#issuecomment-465892279) a while ago. It can also be enabled and disabled from config. 