### PR TITLE
Allow inline html in _index

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,3 +34,8 @@ footnotereturnlinkcontents = "↩"
 [params]
     description = "A website built through Hugo and blogdown."
     footer = "&copy; [Yihui Xie](https://yihui.name) 2017 -- 2019 | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Starting with hugo 0.60, the default markdown renderer changed from
blackdown to goldmark. By default, goldmark does not render raw HTML so
specifying raw html in `_index.Rmarkdown` (in this instance to customize
an image's display) no longer worked as it was processed by goldmark
rather than through pandoc and therefore created an html file with
`<!-- raw HTML omitted -->` rather than the correct html to display
the image.

To allow for raw html, I mv'd the file from a Rmarkdown extension to
an Rmd one and removed the intermediate generated markdown file. The
site now correctly displays the image again since pandoc creates the
appropriate html rather than goldmark excluding it.