### PR TITLE
display current year in footer

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -4,7 +4,8 @@ title: "A minimal Hugo website"
 theme: "hugo-xmin"
 googleAnalytics: ""
 disqusShortname: ""
-ignoreFiles: ["\\.Rmd$", "\\.Rmarkdown$", "_cache$", "\\.knit\\.md$", "\\.utf8\\.md$"]
+ignoreFiles:
+  ["\\.Rmd$", "\\.Rmarkdown$", "_cache$", "\\.knit\\.md$", "\\.utf8\\.md$"]
 footnotereturnlinkcontents: "↩"
 
 permalinks:
@@ -30,7 +31,7 @@ menu:
 
 params:
   description: "A website built through Hugo and blogdown."
-  footer: "&copy; [Yihui Xie](https://yihui.org) 2017 -- 2021 | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
+  footer: "&copy; [Yihui Xie](https://yihui.org) 2017 -- {year} | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
 
 markup:
   highlight:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -30,7 +30,7 @@ menu:
 
 params:
   description: "A website built through Hugo and blogdown."
-  footer: "&copy; [Yihui Xie](https://yihui.org) 2017 -- {year} | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
+  footer: "&copy; [Yihui Xie](https://yihui.org) 2017 -- {Year} | [Github](https://github.com/yihui) | [Twitter](https://twitter.com/xieyihui)"
 
 markup:
   highlight:

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -4,8 +4,7 @@ title: "A minimal Hugo website"
 theme: "hugo-xmin"
 googleAnalytics: ""
 disqusShortname: ""
-ignoreFiles:
-  ["\\.Rmd$", "\\.Rmarkdown$", "_cache$", "\\.knit\\.md$", "\\.utf8\\.md$"]
+ignoreFiles: ["\\.Rmd$", "\\.Rmarkdown$", "_cache$", "\\.knit\\.md$", "\\.utf8\\.md$"]
 footnotereturnlinkcontents: "↩"
 
 permalinks:

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   {{ partial "foot_custom.html" . }}
   {{ with .Site.Params.footer }}
   <hr/>
-  {{ . | markdownify }}
+  {{ replace . "{year}" now.Year | markdownify}}
   {{ end }}
   </footer>
   </body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   {{ partial "foot_custom.html" . }}
   {{ with .Site.Params.footer }}
   <hr/>
-  {{ replace . "{year}" now.Year | markdownify}}
+  {{ replace . "{Year}" now.Year | markdownify}}
   {{ end }}
   </footer>
   </body>


### PR DESCRIPTION
Users of this theme currently have to manually enter the current year, every year, to have an up to date footer. 

This PR will display the current year in the footer with `{{ replace . "{year}" now.Year | markdownify}}`. 