### PR TITLE
Make line-height unitless

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,7 +2,7 @@ body {
   max-width: 800px;
   margin: auto;
   padding: 1em;
-  line-height: 1.5em;
+  line-height: 1.5;
 }
 
 /* header and footer areas */


### PR DESCRIPTION
With fixed units, the line height is too small for headings that wrap (e.g., long post titles).