### PR TITLE
Add demosite for "Demo" button on themes.gohugo.io

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,6 +3,7 @@ license = "MIT"
 licenselink = "https://github.com/yihui/hugo-xmin/blob/master/LICENSE.md"
 description = "eXtremely Minimal Hugo theme: about 150 lines of code in total, including HTML and CSS"
 homepage = "https://xmin.yihui.org"
+demosite = "https://xmin.yihui.org/"
 tags = ["minimal", "blog", "personal", "clean", "simple", "starter", "minimalist"]
 features = ["blog"]
 min_version = "0.18"


### PR DESCRIPTION
At https://themes.gohugo.io/themes/hugo-xmin/ there is no direct link to the demo site. This PR adds the demosite variable (idk what its called) in theme.toml, which is necessary for the "Demo" button. See https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration.
See a theme with a direct link to the demo site: https://themes.gohugo.io/themes/hugo-book/.