### PR TITLE
feat: Make the date format customisable

### DIFF
--- a/exampleSite/content/about.md
+++ b/exampleSite/content/about.md
@@ -49,6 +49,8 @@ params:
 
 Here `{Year}` means the year in which the site is built (usually the current year).
 
+The format for displaying dates can be defined in `.Params.dateFormat`. The value of this configuration should be based on [Go's reference time](https://gohugo.io/functions/time/format/#layout-string). For instance, to display the date as `YYYY-MM-DD` the value of this site paramter should be `2006-01-02`.
+
 ## Custom layouts
 
 There are two layout files under `layouts/_partials/` that you may want to override: `head_custom.html` and `foot_custom.html`. This is how you inject arbitrary HTML code to the head and foot areas. For example, this site has a file `layouts/_partials/foot_custom.html` to support LaTeX math via KaTeX and center images automatically:

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -11,7 +11,7 @@
   {{ if .IsHome }}{{ $pages = .Site.RegularPages }}{{ end }}
   {{ range (where $pages "Section" "!=" "") }}
   <li>
-    <span class="date">{{ .Date.Format "2006/01/02" }}</span>
+    <span class="date">{{ .Date.Format (default "2006/01/02" .Site.Params.dateFormat) }}</span>
     <a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a>
   </li>
   {{ end }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -2,7 +2,7 @@
 <div class="article-meta">
 <h1><span class="title">{{ .Title | markdownify }}</span></h1>
 {{ with .Params.author }}<h2 class="author">{{ . }}</h2>{{ end }}
-{{ if (gt .Params.date 0) }}<h2 class="date">{{ .Date.Format "2006/01/02" }}</h2>{{ end }}
+{{ if (gt .Params.date 0) }}<h2 class="date">{{ .Date.Format (default "2006/01/02" .Site.Params.dateFormat) }}</h2>{{ end }}
 </div>
 
 <main>


### PR DESCRIPTION
Thank you for this great, minimalist Hugo theme. I really like the look and its simplicity. I am completely new to Hugo, but I was able to easily edit the existing templates by looking at the documentation and the example site.

One feature that I wanted was to be able to customize the date format, and display dates as `2006-01-02`. This PR adds that feature. This works, but ...

I am not entirely certain that using a partial is the right solution here, as a site-level configuration variable feels more appropriate. However, I was not able to figure out how to define a "default" format without using an `if-else` block, so I chose to implement this using partials.

The if-else block would reduce the readability of the existing `single.html` template, as it may look something like this:

```
{{ if .Site.Params.dateFormat }}{{ .Date.Format .Site.Params.dateFormat }}{{ else }} {{.Date.Format "2006/01/02" }}{{ end }}
```